### PR TITLE
Mark report.json as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+report.json linguist-generated


### PR DESCRIPTION
So viewing diff on web will automatically filter out noise 