### PR TITLE
Decompile dread.c

### DIFF
--- a/src/ps2/veronica/prog/dread.c
+++ b/src/ps2/veronica/prog/dread.c
@@ -339,15 +339,13 @@ void bhReadWeaponData()
 // 94.11% matching
 unsigned char* bhKeepObjWork(ML_WORK* mp, unsigned char* sp)
 {
-    unsigned char* owp; // not from the debugging symbols
+    sp = (unsigned char*)(((int)sp + 15) & ~0xF);
 
-    owp = (unsigned char*)(((int)sp + 15) & ~0xF);
-    
-    mp->owP = (O_WORK*)owp;
-    
-    memset(owp, 0, mp->obj_num * 80);
-    
-    owp += mp->obj_num * 80;
-    
-    return owp;
+    mp->owP = (O_WORK*)sp;
+
+    memset(sp, 0, mp->obj_num * 80);
+
+    sp += mp->obj_num * 80;
+
+    return sp;
 }


### PR DESCRIPTION
Brings `dread.c` to 100% matched code (all functions byte-exact, verified with objdiff-cli). Full build passes; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)